### PR TITLE
Bump ahash dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["containers", "Rc", "Arc", "weak", "no_std"]
 edition = "2018"
 
 [dependencies]
-ahash = { version = "0.7.6", optional = true, features = [] }
+ahash = { version = "0.8.5", optional = true, features = [] }
 
 [dev-dependencies]
 quickcheck = "1"


### PR DESCRIPTION
The previous version had a bug, and was yanked.