### PR TITLE
Upgrade to ahash 0.8.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog] and this project adheres to
   share code.
 - A great deal of common code has been extracted into macros,
   to avoid the risk of copy-and-paste errors.
+- When ahash is enabled, we now use version 0.8.12 or later.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ std = []
 alloc = []
 
 [dependencies]
-ahash = { version = "0.7.6", optional = true, features = [] }
+ahash = { version = "0.8.12", optional = true, default-features = false, features = ["runtime-rng"] }
 hashbrown = { version = "0.16.1", default-features = false, features = ["inline-more"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Additionally, disable all unnecessary features in the ahash crate.